### PR TITLE
Fixed Ubuntu and Debian GNU TLS package instr.

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
         $ sudo yum install gnutls-devel
         $ sudo yum install libuuid-devel
         $ sudo yum install cmake
-        $ sudo yum install gnutls-utils
+        $ sudo yum install gnutls-bin
         </code></pre>
       </section>
       <section>
@@ -175,7 +175,7 @@
         $ sudo apt install libgnutls28-dev
         $ sudo apt install uuid-dev
         $ sudo apt install cmake
-        $ sudo apt install gnutls-utils
+        $ sudo apt install gnutls-bin
         </code></pre>
       </section>
       <section>


### PR DESCRIPTION
Hey
The correct package for Ubuntu/Debian systems is `gnutls-bin` instead of `gnutls-utils`

Thanks!